### PR TITLE
Päivittää Geocubesin url:n nykyiseen

### DIFF
--- a/ExploreMapWindow.py
+++ b/ExploreMapWindow.py
@@ -320,7 +320,7 @@ class ExploreMapWindow(QMainWindow):
             # name is first value, year last. separated with an underscore
             layer_name = value[0] + "_" + value[3]
         
-        url = ("http://86.50.168.160/ogiir_cache/wmts/1.0.0/" +
+        url = ("https://vm0160.kaj.pouta.csc.fi/ogiir_cache/wmts/1.0.0/" +
                 "WMTSCapabilities.xml&crs=EPSG:3067&dpiMode=7&format=image/"+
                 "png&layers=" + layer_name + "&styles=default&tileMatrixSet=GRIDI-FIN")
                 
@@ -358,7 +358,7 @@ class ExploreMapWindow(QMainWindow):
             self.canvas.refresh()
             return
         else:
-            self.bg_layer = QgsRasterLayer("url=http://86.50.168.160/ogiir_cache/wmts/1.0.0/" +
+            self.bg_layer = QgsRasterLayer("url=https://vm0160.kaj.pouta.csc.fi/ogiir_cache/wmts/1.0.0/" +
                        "WMTSCapabilities.xml&crs=EPSG:3067&dpiMode=7&format=image/"+
                        "png&layers=" + layer_name.lower() + "&styles=default&tileMatrixSet=GRIDI-FIN", 
                        'GEOCUBES BG-LAYER - TEMPORARY', 'wms')

--- a/MapWindow.py
+++ b/MapWindow.py
@@ -165,11 +165,11 @@ class MapWindow(QMainWindow):
         
         # set layer to canvas
         """
-        url = ("http://86.50.168.160/geoserver/ows?service=wfs&version=2.0.0"+ 
+        url = ("https://vm0160.kaj.pouta.csc.fi/geoserver/ows?service=wfs&version=2.0.0"+ 
         "&request=GetFeature&typename=ogiir:maakuntajako_2018_4500k&pagingEnabled=true")
         self.bg_layer = QgsVectorLayer(url, "BACKGROUND-REMOVE", "WFS")
         """
-        self.bg_layer = QgsRasterLayer("url=http://86.50.168.160/ogiir_cache/wmts/1.0.0/" +
+        self.bg_layer = QgsRasterLayer("url=https://vm0160.kaj.pouta.csc.fi/ogiir_cache/wmts/1.0.0/" +
                        "WMTSCapabilities.xml&crs=EPSG:3067&dpiMode=7&format=image/"+
                        "png&layers=taustakartta&styles=default&tileMatrixSet=GRIDI-FIN", 
                        'GEOCUBES BG-LAYER - TEMPORARY', 'wms')

--- a/PolygonMapWindow.py
+++ b/PolygonMapWindow.py
@@ -106,11 +106,11 @@ class PolygonMapWindow(QMainWindow):
     def showCanvas(self):
         """Shows the map canvas with a vector background map for reference"""
         """
-        url = ("http://86.50.168.160/geoserver/ows?service=wfs&version=2.0.0"+ 
+        url = ("https://vm0160.kaj.pouta.csc.fi/geoserver/ows?service=wfs&version=2.0.0"+ 
         "&request=GetFeature&typename=ogiir:maakuntajako_2018_4500k&pagingEnabled=true")
         #self.bg_layer = QgsVectorLayer(url, "BACKGROUND-REMOVE", "WFS")
         """
-        self.bg_layer = QgsRasterLayer("url=http://86.50.168.160/ogiir_cache/wmts/1.0.0/" +
+        self.bg_layer = QgsRasterLayer("url=https://vm0160.kaj.pouta.csc.fi/ogiir_cache/wmts/1.0.0/" +
                        "WMTSCapabilities.xml&crs=EPSG:3067&dpiMode=7&format=image/"+
                        "png&layers=taustakartta&styles=default&tileMatrixSet=GRIDI-FIN", 
                        'GEOCUBES POLYGON BG-LAYER - TEMPORARY', 'wms')

--- a/geocubes_plugin.py
+++ b/geocubes_plugin.py
@@ -932,10 +932,10 @@ class GeocubesPlugin:
         # create a string to fetch the correct data
         area_name = "ogiir:" + self.admin_area.lower()
         if self.admin_area != "Blocks":
-            area_name = area_name + "_2018_4500k"
+            area_name = area_name + "_4500k"
         
         self.busy_dialog.show()
-        url = ("http://86.50.168.160/geoserver/ows?service=wfs&version=2.0.0"+ 
+        url = ("https://vm0160.kaj.pouta.csc.fi/geoserver/ows?service=wfs&version=2.0.0"+ 
         "&request=GetFeature&typename="+area_name+"&pagingEnabled=true")
         
         # pass url, label and data provider
@@ -1198,7 +1198,7 @@ class GeocubesPlugin:
             self.proj_crs = QgsCoordinateReferenceSystem('EPSG:3067')
             
             # current base url (shared by all queries) of the Geocubes project. Modify if url changes
-            self.url_base = "http://86.50.168.160/geocubes"
+            self.url_base = "https://vm0160.kaj.pouta.csc.fi/geocubes"
 
             
             # box housing a drop-down list of possible raster resolutions


### PR DESCRIPTION
Tehdyt muutokset päivittävät self.url_base-muuttujan arvon ja muut staattiset urlit, jotka viittasivat vanhaan osoitteeseen. Muutoksen jälkeen pluginin pitäisi toimia normaalisti.